### PR TITLE
Adicionada opcao para marcar pedidos como completo quando só tiver produtos virtuais

### DIFF
--- a/admin/views/settings/general-fields.php
+++ b/admin/views/settings/general-fields.php
@@ -53,6 +53,18 @@ return array(
         'default' => 'no',
         'id'    => 'wc_pagseguro_connect_together_options',
     ],
+    'skip_processing_virtual' => [
+        'title' => esc_html(__( 'Produtos Virtuais', 'pagbank-connect')),
+        'label' => esc_html(__('Marcar como Completo após confirmação de pagamento', 'pagbank-connect')),
+        'type'  => 'checkbox',
+        'desc_tip' => true,
+        'description' => esc_html(
+            __(
+                'Por padrão, pedidos só com produtos virtuais tem o status Processando após a confirmação do pagamento.',
+                'pagbank-connect'
+            )),
+        'default' => 'no',
+    ],
 	'title' => [
         'title'       => esc_html( __( 'Título Principal' , 'pagbank-connect' ) ),
         'type'        => 'text',

--- a/src/Connect.php
+++ b/src/Connect.php
@@ -55,6 +55,7 @@ class Connect
         add_filter( 'woocommerce_rest_prepare_shop_order_object', [__CLASS__, 'addOrderMetaToApiResponse'], 10, 3 );
         add_action('woocommerce_admin_order_data_after_order_details', [__CLASS__, 'addPaymentInfoAdmin'], 10, 1);
         add_action('woocommerce_api_wc_order_status', [__CLASS__, 'getOrderStatus']);
+        add_filter('woocommerce_order_item_needs_processing', [__CLASS__, 'orderItemNeedsProcessing'], 10, 3);
 
 
         // Load plugin files
@@ -745,6 +746,32 @@ class Connect
 
         $status = $order->get_status();
         wp_send_json_success($status);    
+    }
+
+    /**
+     * Will check if skip_processing_virtual is enabled and skip processing for virtual products
+     *
+     * @param $needsProcessing
+     * @param $product
+     * @param $orderId
+     *
+     * @return void
+     */
+    public static function orderItemNeedsProcessing($needsProcessing, $product, $orderId)
+    {
+        $order = wc_get_order($orderId);
+        $paymentMethod = $order->get_payment_method();
+        if (strpos($paymentMethod, 'rm-pagbank') === false) {
+            return $needsProcessing;
+        }
+        
+        $isVirtual = $product->is_virtual();
+        $skipProcessing = Params::getConfig('skip_processing_virtual') == 'yes';
+        if ($isVirtual && $skipProcessing) {
+            return false;
+        }
+        
+        return $needsProcessing;
     }
     
     private static function addPagBankMenu()


### PR DESCRIPTION

@ligiasalzano eu testei até que bem. Mas qdo puder, investe 10 min e teste você mesmo. Só lançaremos depois da Black Friday (sem pressa).

<img width="778" alt="Zendesk Docs" src="https://github.com/user-attachments/assets/b3b675c4-ccc4-4e94-bf4e-5c34058bc22f">
