### PR TITLE
Feature/188335538 recurring restricted access

### DIFF
--- a/admin/views/html-recurring-settings-page.php
+++ b/admin/views/html-recurring-settings-page.php
@@ -25,6 +25,6 @@ if (!defined('ABSPATH')) {
         <a href="<?php echo admin_url( 'admin.php?page=wc-settings&tab=checkout&section=rm-pagbank-cc' ) ?>#tab-credit-card" class="nav-tab"><?php esc_html_e('Cartão de Crédito', 'pagbank-connect') ?></a>
         <a href="<?php echo admin_url( 'admin.php?page=wc-settings&tab=checkout&section=rm-pagbank-pix' ) ?>#tab-pix" class="nav-tab"><?php esc_html_e('PIX', 'pagbank-connect') ?></a>
         <a href="<?php echo admin_url( 'admin.php?page=wc-settings&tab=checkout&section=rm-pagbank-boleto' ) ?>#tab-boleto" class="nav-tab"><?php esc_html_e('Boleto', 'pagbank-connect') ?></a>
-        <a href="<?php echo admin_url( 'admin.php?page=wc-settings&tab=checkout&section=rm-pagbank-recurring-settings' ) ?>#tab-recurring" class="nav-tab nav-tab-active"><?php esc_html_e('Recorrência (beta)', 'pagbank-connect') ?></a>
+        <a href="<?php echo admin_url( 'admin.php?page=wc-settings&tab=checkout&section=rm-pagbank-recurring-settings' ) ?>#tab-recurring" class="nav-tab nav-tab-active"><?php esc_html_e('Recorrência', 'pagbank-connect') ?></a>
     </nav>
 </fieldset>

--- a/admin/views/html-settings-page.php
+++ b/admin/views/html-settings-page.php
@@ -29,7 +29,7 @@ use RM_PagBank\Connect\Gateway;
         <a href="<?php echo admin_url( 'admin.php?page=wc-settings&tab=checkout&section=rm-pagbank-cc' ) ?>#tab-credit-card" class="nav-tab <?php echo $this->id === 'rm-pagbank-cc' ? 'nav-tab-active' : '' ?>"><?php esc_html_e('Cartão de Crédito', 'pagbank-connect') ?></a>
         <a href="<?php echo admin_url( 'admin.php?page=wc-settings&tab=checkout&section=rm-pagbank-pix' ) ?>#tab-pix" class="nav-tab <?php echo $this->id === 'rm-pagbank-pix' ? 'nav-tab-active' : '' ?>"><?php esc_html_e('PIX', 'pagbank-connect') ?></a>
         <a href="<?php echo admin_url( 'admin.php?page=wc-settings&tab=checkout&section=rm-pagbank-boleto' ) ?>#tab-boleto" class="nav-tab <?php echo $this->id === 'rm-pagbank-boleto' ? 'nav-tab-active' : '' ?>"><?php esc_html_e('Boleto', 'pagbank-connect') ?></a>
-        <a href="<?php echo admin_url( 'admin.php?page=wc-settings&tab=checkout&section=rm-pagbank-recurring-settings' ) ?>#tab-recurring" class="nav-tab"><?php esc_html_e('Recorrência (beta)', 'pagbank-connect') ?></a>
+        <a href="<?php echo admin_url( 'admin.php?page=wc-settings&tab=checkout&section=rm-pagbank-recurring-settings' ) ?>#tab-recurring" class="nav-tab"><?php esc_html_e('Recorrência', 'pagbank-connect') ?></a>
     </nav>
     <?php if ($this->id === 'rm-pagbank'): ?>
         <h3><?php esc_html_e('Credenciais', 'pagbank-connect') ?></h3>

--- a/admin/views/settings/recurring-fields.php
+++ b/admin/views/settings/recurring-fields.php
@@ -5,12 +5,11 @@ if (!defined('ABSPATH')) {
 
 return array(
     [
-        'title' => esc_html( __( 'Configurações de Recorrência (beta)', 'pagbank-connect' ) ),
+        'title' => esc_html( __( 'Configurações de Recorrência', 'pagbank-connect' ) ),
         'type'  => 'title',
         'desc'  => '<h4>Aceite pagamentos recorrentes e crie um clube de assinaturas</h4>
         <p>Ao ativar a recorrência, você poderá definir as configurações da assinatura em cada produto.</p>
-        <p>Nosso plugin não depende do uso do WooCommerce Subscriptions ou nenhum outro. Consulte a <a href="https://pagsegurotransparente.zendesk.com/hc/pt-br/sections/20410120690829-Recorr%C3%AAncia-e-Clube-de-Assinatura">documentação</a> para mais detalhes.</p>
-        <p>Este é um recurso em fase de testes (beta). Erros podem acontecer, incluindo cobranças a mais ou a menos. Ajude a melhorar <a href="https://pagsegurotransparente.zendesk.com/hc/pt-br/requests/new" target="_blank">reportando os erros</a> que encontrar.</p>',
+        <p>Nosso plugin não depende do uso do WooCommerce Subscriptions ou nenhum outro. Consulte a <a href="https://pagsegurotransparente.zendesk.com/hc/pt-br/sections/20410120690829-Recorr%C3%AAncia-e-Clube-de-Assinatura">documentação</a> para mais detalhes.</p>',
         'id'    => 'wc_pagseguro_connect_regurring_general_options',
     ],
 	[

--- a/src/Connect.php
+++ b/src/Connect.php
@@ -426,6 +426,22 @@ class Connect
 
             update_option('pagbank_db_version', '4.13');
         }
+        
+        if (version_compare($stored_version, '4.25', '<')) {
+            global $wpdb;
+            $contentRestrictionTable = $wpdb->prefix . 'pagbank_content_restriction';
+            $sql = "CREATE TABLE IF NOT EXISTS $contentRestrictionTable
+                    (
+                        user_id    int  not null,
+                        categories text null,
+                        pages      text null,
+                        CONSTRAINT pagbank_content_restriction_pk
+                            UNIQUE (user_id)
+                    )
+                        comment 'User permissions based on subscription status';";
+            $wpdb->query($sql);
+            update_option('pagbank_db_version', '4.25');
+        }
     }
 
     public static function uninstall()

--- a/src/Connect/Payments/CreditCard.php
+++ b/src/Connect/Payments/CreditCard.php
@@ -196,8 +196,8 @@ class CreditCard extends Common
             //get card data from subscription
             global $wpdb;
             $initialSubOrderId = $this->order->get_parent_id('edit');
-            $sql = "SELECT * from {$wpdb->prefix}pagbank_recurring WHERE initial_order_id = 0{$initialSubOrderId}";
-            $recurring = $wpdb->get_row( $wpdb->prepare( $sql ) );
+            $sql = "SELECT * from {$wpdb->prefix}pagbank_recurring WHERE initial_order_id = 0%d;";
+            $recurring = $wpdb->get_row( $wpdb->prepare( $sql, $initialSubOrderId ) );
             $paymentInfo = json_decode($recurring->payment_info);
             $card->setId($paymentInfo->card->id);
             $holder = new Holder();

--- a/src/Connect/Recurring.php
+++ b/src/Connect/Recurring.php
@@ -246,6 +246,37 @@ class Recurring
                     'value' => get_post_meta($post->ID, '_recurring_discount_cycles', true),
                 ]);
                 ?>
+                </div>
+                <div class="options_group">
+                <?php
+                woocommerce_wp_select([
+                    'id' => '_recurring_restricted_pages',
+                    'label' => __('Páginas restritas', 'pagbank-connect'),
+                    'description' => __('Selecione as páginas que só podem ser acessadas por assinantes.', 'pagbank-connect'),
+                    'options' => $this->getPagesOptions(),
+                    'desc_tip' => true,
+                    'value' => get_post_meta($post->ID, '_restricted_pages', true),
+                    'custom_attributes' => ['multiple' => 'multiple'],
+                ]);
+                woocommerce_wp_select([
+                    'id' => '_recurring_restricted_categories',
+                    'label' => __('Categorias restritas', 'pagbank-connect'),
+                    'description' => __('Selecione as categorias que só podem ser acessadas por assinantes.', 'pagbank-connect'),
+                    'options' => $this->getCategoriesOptions(),
+                    'desc_tip' => true,
+                    'value' => get_post_meta($post->ID, '_restricted_categories', true),
+                    'custom_attributes' => ['multiple' => 'multiple'],
+                ]);
+                woocommerce_wp_select([
+                    'id' => '_recurring_restricted_unauthorized_page',
+                    'label' => __('Redirecionar para', 'pagbank-connect'),
+                    'description' => __('Selecione a página que o cliente verá quando não tiver acesso.', 'pagbank-connect'),
+                    'options' => array_merge([''=> __('Selecione', 'pagbank-connect')], $this->getPagesOptions()),
+                    'desc_tip' => true,
+                    'value' => get_post_meta($post->ID, '_restricted_pages', true),
+                ]);
+                
+                ?>
             </div>
             <div class="options_group">
                 <p><?php echo esc_html(
@@ -254,6 +285,24 @@ class Recurring
             </div>
         </div>
         <?php
+    }
+
+    private function getPagesOptions() {
+        $pages = get_pages();
+        $options = [];
+        foreach ($pages as $page) {
+            $options[$page->ID] = $page->post_title . ' (ID: ' . $page->ID . ')';
+        }
+        return $options;
+    }
+
+    private function getCategoriesOptions() {
+        $categories = get_categories();
+        $options = [];
+        foreach ($categories as $category) {
+            $options[$category->term_id] = $category->name . ' (ID: ' . $category->term_id . ')';
+        }
+        return $options;
     }
     
     public function saveRecurringTabContent($postId)
@@ -284,6 +333,18 @@ class Recurring
 
             $cycle = isset($_POST['_recurring_discount_cycles']) ? sanitize_text_field($_POST['_recurring_discount_cycles']) : 0;
             update_post_meta($postId, '_recurring_discount_cycles', $cycle);
+
+            //region Restricted Access (pages and categories - coming soon)
+            $recurringEnabled = isset($_POST['_recurring_enabled']) ? 'yes' : 'no';
+            update_post_meta($postId, '_recurring_enabled', $recurringEnabled);
+
+            $restrictedPages = isset($_POST['_restricted_pages']) ? array_map('sanitize_text_field', $_POST['_restricted_pages']) : [];
+            update_post_meta($postId, '_restricted_pages', $restrictedPages);
+
+            $restrictedCategories = isset($_POST['_restricted_categories']) ? array_map('sanitize_text_field', $_POST['_restricted_categories']) : [];
+            update_post_meta($postId, '_restricted_categories', $restrictedCategories);
+            //@TODO add restricted settings to somewhere we don't have too loop through all products
+            //endregion
         }
     }
     

--- a/src/Connect/Recurring.php
+++ b/src/Connect/Recurring.php
@@ -53,6 +53,24 @@ class Recurring
                 'rm_pagbank_cron_process_recurring_payments'
             );
         }
+
+        add_action('rm_pagbank_cron_process_recurring_cancellations', [$this, 'processRecurringCancellations']);
+        if ( ! wp_next_scheduled('rm_pagbank_cron_process_recurring_cancellations') ) {
+            wp_schedule_event(
+                time(),
+                'daily',
+                'rm_pagbank_cron_process_recurring_cancellations'
+            );
+        }
+
+        add_action('rm_pagbank_cron_process_expired_paused', [$this, 'processRecurringExpiredPaused']);
+        if ( ! wp_next_scheduled('rm_pagbank_cron_process_expired_paused') ) {
+            wp_schedule_event(
+                time(),
+                'daily',
+                'rm_pagbank_cron_process_expired_paused'
+            );
+        }
         //endregion
         
         //region frontend subscription management
@@ -73,6 +91,9 @@ class Recurring
         add_action('woocommerce_before_calculate_totals', [$this, 'handleRecurringProductPrice'], 10, 1);
         add_filter('woocommerce_cart_needs_payment', [$this, 'enablePaymentInTrialOrder'], 10, 2);
         add_action('template_redirect', [$this, 'handleRestrictedAccess']);
+        add_action('pagbank_recurring_cancellation_processed', [$this, 'updateUserRestrictedAccessForSubscription'], 10, 1);
+        add_action('pagbank_recurring_subscription_created_notification', [$this, 'updateUserRestrictedAccessForSubscription'], 10, 1);
+        add_action('pagbank_recurring_subscription_status_changed', [$this, 'updateUserRestrictedAccessForSubscription'], 10, 2);
     }
 
     public static function recurringSettingsFields($settings, $current_section)
@@ -81,9 +102,7 @@ class Recurring
             return $settings;
         }
 
-        $settings = include WC_PAGSEGURO_CONNECT_BASE_DIR.'/admin/views/settings/recurring-fields.php';
-
-        return $settings;
+        return include WC_PAGSEGURO_CONNECT_BASE_DIR.'/admin/views/settings/recurring-fields.php';
     }
 
     public static function recurringHeaderSettingsSection()
@@ -248,6 +267,8 @@ class Recurring
                 ]);
                 ?>
                 </div>
+                <h2><?php echo __('Restringir conteúdo', 'pagbank-connect');?> (beta)<span class="woocommerce-help-tip" tabindex="0" aria-label="<?php echo __('Restrinja o acesso à páginas e categorias somente para assinantes deste produto', 'pagbank-connect')?>" data-tip="<?php echo __('Restrinja o acesso à páginas e categorias somente para assinantes deste produto', 'pagbank-connect')?>"></span></h2>
+                
                 <div class="options_group">
                 <?php
                 woocommerce_wp_select([
@@ -285,6 +306,9 @@ class Recurring
                 <p><?php echo esc_html(
                         __('Alterações de valor, ciclos, taxas, periodos de testes, etc só afetarão futuras assinaturas.', 'pagbank-connect')
                     );?></p>
+                <p><?php echo esc_html(
+                        __('Alterações na restrição de conteúdo terão efeito imediato.', 'pagbank-connect')
+                    );?></p>
             </div>
         </div>
         <?php
@@ -316,8 +340,13 @@ class Recurring
      */
     public function saveRecurringTabContent($postId)
     {
+        $oldRecurringEnabled = get_post_meta($postId, '_recurring_enabled', true);
         $recurringEnabled = isset($_POST['_recurring_enabled']) ? 'yes' : 'no';
         update_post_meta($postId, '_recurring_enabled', $recurringEnabled);
+        if ($oldRecurringEnabled != $recurringEnabled) {
+            delete_transient('recurring_restricted_products');
+            $this->updateAllUsersRestrictedAccess();
+        }
         
         $frequency = isset($_POST['_frequency']) ? sanitize_text_field($_POST['_frequency']) : 'monthly'; //phpcs:ignore WordPress.Security.NonceVerification
         update_post_meta($postId, '_frequency', $frequency);
@@ -356,6 +385,7 @@ class Recurring
 
             if ($oldRestrictedPages != $restrictedPages || $oldRestrictedCategories != $restrictedCategories) {
                 delete_transient('recurring_restricted_products');
+                $this->updateAllUsersRestrictedAccess();
             }
             $unauthoridedPageId = isset($_POST['_recurring_restricted_unauthorized_page']) ? intval(sanitize_text_field($_POST['_recurring_restricted_unauthorized_page'])) : get_option('page_on_front');
             update_post_meta($postId, '_recurring_restricted_unauthorized_page', $unauthoridedPageId);
@@ -384,7 +414,7 @@ class Recurring
         }
         
         if (!$canClearCart) {
-            wc_add_notice(__('Produtos recorrentes ou assinaturas devem ser comprados separadamente. Remova os itens recorrentes do carrinho antes de prosseguir.', 'pagbank-connect'), 'error');
+            \wc_add_notice(__('Produtos recorrentes ou assinaturas devem ser comprados separadamente. Remova os itens recorrentes do carrinho antes de prosseguir.', 'pagbank-connect'), 'error');
             $canBeAdded = false;
         }
 
@@ -492,7 +522,13 @@ class Recurring
 
         return $wpdb->insert($table, $data, $format) !== false;
     }
-    
+
+    /**
+     * Will get subscriptions that are due (or the given subscription) and process the recurring payment
+     * @param stdClass|null $subscription
+     *
+     * @return void
+     */
     public function processRecurringPayments(\stdClass $subscription = null)
     {
         global $wpdb;
@@ -508,6 +544,42 @@ class Recurring
         foreach ($subscriptions as $subscription) {
             $recurringOrder = new Connect\Recurring\RecurringOrder($subscription);
             $recurringOrder->createRecurringOrderFromSub();
+        }
+    }
+
+    /**
+     * Cron job to process recurring cancellations
+     * @return void
+     */
+    public function processRecurringCancellations()
+    {
+        global $wpdb;
+        $now = gmdate('Y-m-d H:i:s');
+        $sql = "SELECT * FROM {$wpdb->prefix}pagbank_recurring 
+         WHERE status = 'PENDING_CANCEL' AND next_bill_at <= canceled_at";
+        $subscriptions = $wpdb->get_results($sql);
+        foreach ($subscriptions as $subscription) {
+            $subscription->status = 'CANCELED';
+            $wpdb->update($wpdb->prefix . 'pagbank_recurring', ['status' => $subscription->status], ['id' => $subscription->id]);
+            do_action('pagbank_recurring_cancellation_processed', $subscription);
+        }
+    }
+    
+    /**
+     * Process subscriptions that are due but paused and trigger further actions
+     * @return void
+     */
+    public function processRecurringExpiredPaused()
+    {
+        global $wpdb;
+        $now = gmdate('Y-m-d H:i:s');
+        $sql = "SELECT * FROM {$wpdb->prefix}pagbank_recurring 
+         WHERE status = 'PAUSED' AND next_bill_at <= '%s'";
+        $subscriptions = $wpdb->get_results($wpdb->prepare($sql, $now));
+        foreach ($subscriptions as $subscription) {
+            //remove access to restricted content if any
+            $this->updateUserRestrictedAccessForSubscription($subscription);
+            do_action('pagbank_recurring_expired_paused_processed', $subscription);
         }
     }
     
@@ -870,14 +942,14 @@ class Recurring
         
         $referrer = wp_get_referer() ? wp_get_referer() : home_url();
         if (empty($subscriptionId) || empty($action)) {
-            wc_add_notice(__('Ação inválida. Verifique se o identificador da assinatura é válido.', 'pagbank-connect'), 'error');
+            \wc_add_notice(__('Ação inválida. Verifique se o identificador da assinatura é válido.', 'pagbank-connect'), 'error');
             wp_safe_redirect($referrer);
             return;
         }
 
         $subscription = $this->getSubscription($subscriptionId);
         if ( ! $subscription->id ) {
-            wc_add_notice(__('Assinatura não encontrada.', 'pagbank-connect'), 'error');
+            \wc_add_notice(__('Assinatura não encontrada.', 'pagbank-connect'), 'error');
             wp_safe_redirect($referrer);
             return;
         }
@@ -900,7 +972,7 @@ class Recurring
         }
 
         if ( ! method_exists($this, $action . 'SubscriptionAction')) {
-            wc_add_notice(__('Ação não implementada.', 'pagbank-connect'), 'error');
+            \wc_add_notice(__('Ação não implementada.', 'pagbank-connect'), 'error');
             wp_safe_redirect($referrer);
             return;
         }
@@ -971,14 +1043,30 @@ class Recurring
                         $initialOrder
                     );
             }
+            
+            //if canceled, remove the user content authorizations
+            if ($newStatus == 'CANCELED') {
+                $order = wc_get_order($subscription->initial_order_id);
+                $userId = $order->get_customer_id();
+                $this->updateUserRestrictions($userId);
+            }
         }
         
         if ($update > 0) {
-            wc_add_notice(__('Assinatura cancelada com sucesso.', 'pagbank-connect'));
+            if(defined('DOING_CRON') && DOING_CRON){
+                Functions::log('Assinatura cancelada com sucesso.', 'info', ['subscription id' => $subscription->id]);
+                return;
+            }
+            \wc_add_notice(__('Assinatura cancelada com sucesso.', 'pagbank-connect'));
             return;            
         }
         
-        wc_add_notice(__('Não foi possível cancelar a assinatura.', 'pagbank-connect'), 'error');
+        if(defined('DOING_CRON') && DOING_CRON){
+            Functions::log('Não foi possível cancelar a assinatura.', 'error', ['subscription id' => $subscription->id]);
+            return;
+        }
+        
+        \wc_add_notice(__('Não foi possível cancelar a assinatura.', 'pagbank-connect'), 'error');
     }
 
     /** @noinspection PhpUnused */
@@ -987,7 +1075,7 @@ class Recurring
         global $wpdb;
         $initialOrder = wc_get_order($subscription->initial_order_id);
         if ($subscription->status != 'PENDING_CANCEL') {
-            wc_add_notice(__('O status atual da assinatura não permite esta alteração.', 'pagbank-connect'), 'error');
+            \wc_add_notice(__('O status atual da assinatura não permite esta alteração.', 'pagbank-connect'), 'error');
             return;
         }
         
@@ -1008,11 +1096,11 @@ class Recurring
         }
         
         if ($update > 0) {
-            wc_add_notice(__('Cancelamento suspenso com sucesso. Sua assinatura foi resumida.', 'pagbank-connect'));
+            \wc_add_notice(__('Cancelamento suspenso com sucesso. Sua assinatura foi resumida.', 'pagbank-connect'));
             return;
         }
         
-        wc_add_notice(__('Não foi possível suspender o cancelamento da assinatura.', 'pagbank-connect'), 'error');
+        \wc_add_notice(__('Não foi possível suspender o cancelamento da assinatura.', 'pagbank-connect'), 'error');
     }
 
     /**
@@ -1028,7 +1116,7 @@ class Recurring
         global $wpdb;
         $initialOrder = wc_get_order($subscription->initial_order_id);
         if ($subscription->status != 'ACTIVE' && $subscription->status != 'PENDING') {
-            wc_add_notice(__('O status atual da assinatura não permite esta alteração.', 'pagbank-connect'), 'error');
+            \wc_add_notice(__('O status atual da assinatura não permite esta alteração.', 'pagbank-connect'), 'error');
             return;
         }
         $update = $wpdb->update($wpdb->prefix . 'pagbank_recurring',
@@ -1046,10 +1134,10 @@ class Recurring
             
         }
         if ($update > 0){
-            wc_add_notice(__('Assinatura pausada com sucesso.', 'pagbank-connect'));
+            \wc_add_notice(__('Assinatura pausada com sucesso.', 'pagbank-connect'));
             return;
         }
-        wc_add_notice(__('Não foi possível pausar a assinatura.', 'pagbank-connect'), 'error');
+        \wc_add_notice(__('Não foi possível pausar a assinatura.', 'pagbank-connect'), 'error');
     }
 
     /** @noinspection PhpUnused */
@@ -1060,7 +1148,7 @@ class Recurring
         $status = 'ACTIVE';
 
         if ($subscription->status != 'PAUSED') {
-            wc_add_notice(__('O status atual da assinatura não permite esta alteração.', 'pagbank-connect'), 'error');
+            \wc_add_notice(__('O status atual da assinatura não permite esta alteração.', 'pagbank-connect'), 'error');
             return;
         }
         //if next_bill_at < current date, update the next_bill_at with current time
@@ -1084,7 +1172,7 @@ class Recurring
 
         if ($update > 0)
         {
-            wc_add_notice(__('Assinatura resumida com sucesso.', 'pagbank-connect'));
+            \wc_add_notice(__('Assinatura resumida com sucesso.', 'pagbank-connect'));
             do_action(
                 'pagbank_recurring_subscription_unpaused_notification',
                 $subscription,
@@ -1093,7 +1181,7 @@ class Recurring
             return;
         }
         
-        wc_add_notice(__('Não foi possível resumir a assinatura.', 'pagbank-connect'), 'error');
+        \wc_add_notice(__('Não foi possível resumir a assinatura.', 'pagbank-connect'), 'error');
     }
 
     /**
@@ -1113,10 +1201,10 @@ class Recurring
         ]);
 
         if ($update){
-            wc_add_notice(__('Assinatura atualizada com sucesso.', 'pagbank-connect'));
+            \wc_add_notice(__('Assinatura atualizada com sucesso.', 'pagbank-connect'));
             return;
         }
-        wc_add_notice(__('Não foi possível atualizar a assinatura.', 'pagbank-connect'), 'error');
+        \wc_add_notice(__('Não foi possível atualizar a assinatura.', 'pagbank-connect'), 'error');
     }
     // endregion
 
@@ -1186,34 +1274,18 @@ class Recurring
 
     public function handleRestrictedAccess() {
         if ((!is_page() && !is_single()) || is_product_category() || is_product() || is_shop()) {
-            return;
+            return; //has access
         }
         
         $pageId = get_the_ID();
         $categoryId = $this->getPostCategories();
         $userId = get_current_user_id();
-
-        // Get all restricted products from cache or database
-        $restrictedProducts = get_transient('recurring_restricted_products');
-        if ($restrictedProducts === false) {
-            $restrictedProducts = get_posts([
-                'post_type' => 'product',
-                'fields' => 'ids',
-                'meta_query' => [
-                    [
-                        'key' => '_recurring_restriction_active',
-                        'value' => 1,
-                    ],
-                ],
-                'numberposts' => -1,
-            ]);
-            set_transient('recurring_restricted_products', $restrictedProducts, HOUR_IN_SECONDS);
-        }
+        $restrictedProducts = $this->getProductsWithRestriction();
 
         if (empty($restrictedProducts)) {
             return;
         }
-
+        
         // Check if the current page or category is restricted
         $restrictedProductIds = [];
         $isPageRestricted = false;
@@ -1235,51 +1307,33 @@ class Recurring
             $this->redirectToUnauthorizedPage($product ?? 0);
         }
 
-        
-        
-        // Get all order IDs for the current user
-        $orders = wc_get_orders([
-            'customer' => $userId,
-            'limit' => -1,
-        ]);
-
-        $orderIds = array_map(function($order) {
-            return $order->get_id();
-        }, $orders);
-
-        if (empty($orderIds)) {
-            $this->redirectToUnauthorizedPage($restrictedProductIds[0]);
+        $recHelper = new RecurringHelper();
+        if ($recHelper->canAccessRestrictedContent($userId, $pageId, $categoryId)) {
+            return;
         }
 
-        // Get all active subscriptions for the current user's orders
-        global $wpdb;
-        $orderIdsString = implode(',', array_map('intval', $orderIds));
-        $subscriptions = $wpdb->get_results(
-            "SELECT * FROM {$wpdb->prefix}pagbank_recurring WHERE status = 'ACTIVE' AND initial_order_id IN ($orderIdsString)"
-        );
-
-        if (empty($subscriptions)) {
-            $this->redirectToUnauthorizedPage($restrictedProductIds[0]);
-        }
-
-        // Check if the user has an active subscription for any of the restricted products
-        foreach ($subscriptions as $subscription) {
-            $order = wc_get_order($subscription->initial_order_id);
-            if (!$order) {
-                continue;
-            }
-
-            foreach ($order->get_items() as $item) {
-                if (in_array($item->get_product_id(), $restrictedProductIds)) {
-                    return; // User has access
-                }
-            }
-        }
-
-        // If no active subscription found, redirect to unauthorized page
-        $this->redirectToUnauthorizedPage($restrictedProductIds[0]);
+        $this->redirectToUnauthorizedPage($product ?? 0);
     }
 
+    /**
+     * Update user restricted access for a given subscription
+     * @param $subscription
+     *
+     * @return void
+     */
+    public function updateUserRestrictedAccessForSubscription($subscription)
+    {
+        if (!isset($subscription->initial_order_id)) {
+            return;
+        }
+        $order = wc_get_order($subscription->initial_order_id);
+        if (!$order) {
+            return;
+        }
+        $userId = $order->get_customer_id();
+        $this->updateUserRestrictions($userId);
+    }
+    
     public function getPostCategories(): array
     {
         $categories = get_the_category();
@@ -1292,37 +1346,198 @@ class Recurring
         }
         return $category_ids;
     }
+    
+    public function updateUserRestrictionsAfterOrderIsPaid($order, $orderData)
+    {
+        $isRecurring = $order->get_meta('_pagbank_is_recurring');
+        $userId = $order->get_customer_id();
+        if ($isRecurring && $userId) {
+            $this->updateUserRestrictions($userId);
+        }
+    }
+
+    /**
+     * @param $productId
+     *
+     * @return void
+     */
     public function redirectToUnauthorizedPage($productId) {
         $unauthorizedPageId = get_post_meta($productId, '_recurring_restricted_unauthorized_page', true);
         wp_redirect(get_permalink($unauthorizedPageId));
         exit;
     }
 
+    
     /**
-     * Deletes all transients matching the given pattern (i.e.: foo% will delete _transient_foo_123, etc)
-     * @param $nameLike
+     * Get all restricted products from cache or database
+     * @return int[]|mixed|\WP_Post[]
+     */
+    protected function getProductsWithRestriction()
+    {
+        $restrictedProducts = get_transient('recurring_restricted_products');
+        if ($restrictedProducts === false) {
+            $restrictedProducts = get_posts([
+                'post_type'   => 'product',
+                'fields'      => 'ids',
+                'meta_query'  => [
+                    [
+                        'key'   => '_recurring_restriction_active',
+                        'value' => 1,
+                    ],
+                ],
+                'numberposts' => -1,
+            ]);
+            set_transient('recurring_restricted_products', $restrictedProducts, HOUR_IN_SECONDS);
+        }
+
+        return $restrictedProducts;
+    }
+
+    /**
+     * @param int|null $userId
+     *
+     * @return stdClass|WC_Order[]
+     */
+    protected function getUserRecurringOrders(int $userId = null)
+    {
+        $userId = $userId ?? get_current_user_id();
+        // Check if HPOS is enabled
+        if (wc_get_container()->get(\Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::class)->custom_orders_table_usage_is_enabled()) {
+            return wc_get_orders([
+                'customer_id' => $userId,
+                'limit'       => -1,
+                'meta_query' => [
+                    'relation' => 'AND',
+                    [
+                        'key' => '_pagbank_recurring_initial',
+                        'value' => '1',
+                    ]
+                ]
+            ]);
+        }
+        // else, HPOS is disabled
+        $args = array(
+            'post_type'      => 'shop_order',
+            'posts_per_page' => -1,
+            'post_status'    => 'any',
+            'orderby'        => 'date',
+            'order'          => 'DESC',
+            'meta_query'     => [
+                'relation' => 'AND',
+                [
+                    'key'     => '_pagbank_recurring_initial',
+                    'value'   => '1',
+                    'compare' => '='
+                ],
+                [
+                    'key'     => '_customer_user',
+                    'value'   => $userId,
+                    'compare' => '='
+                ]
+            ],
+        );
+
+        $query = new \WP_Query($args);
+
+        $recurringOrders = [];
+        if ($query->have_posts()) {
+            while ($query->have_posts()) {
+                $query->the_post();
+                $order_id = get_the_ID();
+                $order = wc_get_order($order_id);
+                $recurringOrders[] = $order;
+            }
+            wp_reset_postdata();
+        }
+
+        return $recurringOrders;
+    }
+
+    /**
+     * @param $userId
      *
      * @return void
      */
-    function deleteTransientLike($nameLike) {
+    public function updateUserRestrictions($userId)
+    {
+        $userRecurringOrders = $this->getUserRecurringOrders($userId);
+        if (empty($userRecurringOrders)) {
+            return;
+        }
+        
+        $allowedPages = [];
+        $allowedCategories = [];
+        $recHelper = new RecurringHelper();
+        foreach ($userRecurringOrders as $order) {
+            $subscription = $this->getSubscriptionFromOrder($order);
+            if (!$subscription || !$recHelper->areBenefitsActive($subscription)) {
+                continue;
+            }
+            foreach($order->get_items() as $item) {
+                $originalItem = wc_get_product($item->get_product_id());
+                if ($originalItem->get_meta('_recurring_enabled') != 'yes') {
+                    continue;
+                }
+                    
+                $restrictedPages = get_post_meta($originalItem->get_id(), '_recurring_restricted_pages', true);
+                $restrictedCategories = get_post_meta($originalItem->get_id(), '_recurring_restricted_categories', true);
+                $allowedPages = array_merge($allowedPages, $restrictedPages);
+                $allowedCategories = array_merge($allowedCategories, $restrictedCategories);
+            }
+        }
+        
+        $allowedPages = array_unique($allowedPages);
+        $allowedCategories = array_unique($allowedCategories);
+        $this->updateUserRestrictionsContent($userId, $allowedPages, $allowedCategories);
+        
+    }
+
+    /**
+     * @param $uscerId
+     * @param $restrictedPages
+     * @param $restrictedCategories
+     *
+     * @return void
+     */
+    public function updateUserRestrictionsContent($userId, $restrictedPages, $restrictedCategories)
+    {
+        // create new entry on pagbank_content_restriction if user is not listed there
         global $wpdb;
-
-        // Query to find all transients matching the pattern
-        $transients = $wpdb->get_col(
-            $wpdb->prepare(
-                "SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE %s OR option_name LIKE %s",
-                '_transient_' . $nameLike,
-                '_transient_timeout_' . $nameLike
-            )
-        );
-
-
-        // Loop through each transient and delete it
-        foreach ($transients as $transient) {
-            $transient_name = str_replace('_transient_', '', $transient);
-            delete_transient($transient_name);
+        $table = $wpdb->prefix . 'pagbank_content_restriction';
+        $query = $wpdb->prepare("SELECT * FROM $table WHERE user_id = %d", $userId);
+        $user = $wpdb->get_row($query);
+        $restrictedPages = $restrictedPages ? implode(',', $restrictedPages) : null;
+        $restrictedCategories = $restrictedCategories ? implode(',', $restrictedCategories) : null;
+        if (is_null($user)) {
+            $wpdb->insert($table, ['user_id' => $userId, 'pages' => $restrictedPages, 'categories' => $restrictedCategories]);
+            return;
+        }
+        //or update the existing entry
+        $wpdb->update($table, ['pages' => $restrictedPages, 'categories' => $restrictedCategories], ['user_id' => $userId]);
+    }
+    
+    public function updateAllUsersRestrictedAccess()
+    {
+        //all subscriptions
+        global $wpdb;
+        $table = $wpdb->prefix . 'pagbank_recurring';
+        $query = "SELECT * FROM $table WHERE status IN ('ACTIVE', 'PAUSED', 'PENDING_CANCEL')";
+        $subscriptions = $wpdb->get_results($query);
+        if (empty($subscriptions)) {
+            return;
+        }
+        $usersNeedUpdate = [];
+        foreach ($subscriptions as $subscription) {
+            $order = wc_get_order($subscription->initial_order_id);
+            $userId = $order->get_customer_id();
+            if (!in_array($userId, $usersNeedUpdate)) {
+                $usersNeedUpdate[] = $userId;
+            }
+        }
+        foreach ($usersNeedUpdate as $userId) {
+            $this->updateUserRestrictions($userId);
         }
     }
 
-
+    
 }

--- a/src/Connect/Recurring/Emails/CanceledSubscription.php
+++ b/src/Connect/Recurring/Emails/CanceledSubscription.php
@@ -19,8 +19,9 @@ if ( ! class_exists( 'CanceledSubscription', false ) ) :
      * @copyright 2023 Magenteiro
      */
     class CanceledSubscription extends WC_Email {
+        private $subscription;
 
-		/**
+        /**
 		 * Constructor.
 		 */
 		public function __construct() {
@@ -88,7 +89,10 @@ if ( ! class_exists( 'CanceledSubscription', false ) ) :
             
             $this->placeholders['{subscription_id}'] = $subscription->id;
             $this->placeholders['{next_bill_at}'] = gmdate('d/m/Y', strtotime($subscription->next_bill_at));
-            $this->placeholders['{canceled_at}'] = gmdate('d/m/Y', strtotime($subscription->canceled_at));
+            $this->placeholders['{canceled_at}'] = '';
+            if (isset($subscription->canceled_at)) {
+                $this->placeholders['{canceled_at}'] = gmdate('d/m/Y', strtotime($subscription->canceled_at));
+            }
             $this->subscription = $subscription;
 
 			if ( $this->is_enabled() && $this->get_recipient() ) {

--- a/src/Connect/Recurring/Emails/NewSubscription.php
+++ b/src/Connect/Recurring/Emails/NewSubscription.php
@@ -20,8 +20,9 @@ if ( ! class_exists( 'NewSubscription', false ) ) :
      * @copyright 2023 Magenteiro
      */
     class NewSubscription extends RecurringEmails {
+        private $subscription;
 
-		/**
+        /**
 		 * Constructor.
 		 */
 		public function __construct() {
@@ -88,7 +89,10 @@ if ( ! class_exists( 'NewSubscription', false ) ) :
             
             $this->mergePlaceholders($subscription);
             $this->placeholders['{next_bill_at}'] = gmdate('d/m/Y', strtotime($subscription->next_bill_at));
-            $this->placeholders['{canceled_at}'] = gmdate('d/m/Y', strtotime($subscription->canceled_at));
+            $this->placeholders['{canceled_at}'] = '';
+            if (isset($subscription->canceled_at)) {
+                $this->placeholders['{canceled_at}'] = gmdate('d/m/Y', strtotime($subscription->canceled_at));
+            }
             $this->subscription = $subscription;
 
 			if ( $this->is_enabled() && $this->get_recipient() ) {

--- a/src/Helpers/Recurring.php
+++ b/src/Helpers/Recurring.php
@@ -412,4 +412,26 @@ class Recurring
         return (float)$product->get_meta('_recurring_discount_amount') > 0
         && (int)$product->get_meta('_recurring_discount_cycles') > 0;
     }
+    
+    public function isUserActiveOnProduct($productId): bool
+    {
+        // select user orders that are in pagbank_recurring table with an active status
+        // join with the items table to get the product id
+        // and return true if the product id is the same as the one passed
+        global $wpdb;
+        $table = $wpdb->prefix . 'pagbank_recurring';
+        $sql = "SELECT * FROM `$table` WHERE user_id = %d AND status = 'ACTIVE'";
+        $subscriptions = $wpdb->get_results($wpdb->prepare($sql, get_current_user_id()));
+        if (!$subscriptions) return false;
+        foreach ($subscriptions as $subscription){
+            $order = wc_get_order($subscription->initial_order_id);
+            if (!$order) continue;
+            foreach ($order->get_items() as $item){
+                $product = $item->get_product();
+                if ($product->get_id() == $productId){
+                    return true;
+                }
+            }
+        }
+    }
 }

--- a/src/Traits/ProcessPayment.php
+++ b/src/Traits/ProcessPayment.php
@@ -124,6 +124,7 @@ trait ProcessPayment
                 $recurring->updateSubscription($subscription, [
                     'status' => $shouldBeStatus,
                 ]);
+                do_action('pagbank_recurring_subscription_status_changed', $subscription, $shouldBeStatus);
             }
 
             if ($shouldBeStatus == 'ACTIVE') {


### PR DESCRIPTION
@ligiasalzano este PR traz um recurso muito esperado e um grande diferencial.
Eu passei boa parte do dia testando todos os detalhes que eu podia imaginar, mas conto com você pra me ajudar a testar mais.

**Instruções**
1. Ao fazer checkout deste branch, altere a versão do plugin pra 4.25.0. Você deve fazer isso no readme.txt e no rm-pagbank.php (nos comentários e na constante). Se tudo der certo você verá uma nova tabela ( `_wp_pagbank_content_restriction`)
2. Crie um produto de assinatura, e verá uma nova área na aba de assinatura. Lá você poderá restringir o acesso à paginas ou categorias somente pra quem tiver acesso.

O que é esperado:
* Que só quem tiver uma assinatura ativa (mesmo que pausada mas não vencida ou aguardando cancelamento) consiga acessar tais páginas/categorias.
* Que a pessoa que não estiver logada ou não tiver permissão seja redirecionada
* Que todos que tem assinatura de um produto seja afetado quando ele sofrer alterações de restrição ou suas assinaturas deixarem de estar válidas
* Que isso não impacte a performance do site nem do admin. 


O que eu testei (entre outras coisas):
- [x] Pagamento de produto normal
- [x] Cliente assinou e pausou, continua com acesso
- [x] Assinatura pausada tem restrição bloqueada automaticamente
- [x] Assinatura PENDING_CANCEL consegue acessar
- [x] PENDING_CANCEL é cancelada na data e acesso é bloqueado
- [x] Ao alterar restrição de produto os clientes são atualizados, incluindo aqueles em PENDING_CANCEL ou PAUSED se dentro do limite
- [x] Outras páginas e categorias podem ser acessadas por usuários logados ou não
- [x] Quando a recorrencia falha e assinatura é cancelada, o acesso é removido
- [x] Criar pedido com outro meio de pagamento
- [x] Processar atualizações de restrição com HPOS desativado

_Se puder, teste isso até minha segunda-feira (seu domingo)_

Obrigado pela ajuda. 
PS: fique a vontade pra aceitar o merge se não encontrar nada errado 