### PR TITLE
Correção/melhoria: em alguns cenários, dependendo da configuração ou …

### DIFF
--- a/src/Connect/Standalone/CreditCard.php
+++ b/src/Connect/Standalone/CreditCard.php
@@ -135,11 +135,13 @@ class CreditCard extends WC_Payment_Gateway_CC
      * @inheritDoc
      */
     public function form() {
+        
         if ($this->paymentUnavailable()) {
             include WC_PAGSEGURO_CONNECT_BASE_DIR . '/src/templates/unavailable.php';
             return;
         }
 
+        $this->addScripts(true);
         include WC_PAGSEGURO_CONNECT_BASE_DIR . '/src/templates/payments/creditcard.php';
     }
 
@@ -351,7 +353,7 @@ class CreditCard extends WC_Payment_Gateway_CC
      * Add js files for checkout and success page
      * @return void
      */
-    public function addScripts() {
+    public function addScripts($force=false) {
 
         // If the method has already been called, return early
         if (self::$addedScripts) {
@@ -368,17 +370,20 @@ class CreditCard extends WC_Payment_Gateway_CC
         }
 
         $alreadyEnqueued = wp_script_is('pagseguro-checkout-sdk');
-        if ( is_checkout() && !is_order_received_page() && !$alreadyEnqueued ) {
-            wp_enqueue_script('pagseguro-checkout-sdk',
-                'https://assets.pagseguro.com.br/checkout-sdk-js/rc/dist/browser/pagseguro.min.js',
-                [],
-                WC_PAGSEGURO_CONNECT_VERSION,
-                true
-            );
+        if ($force || (is_checkout() && !is_order_received_page()) ) {
+            if ( !$alreadyEnqueued ) {
+                wp_enqueue_script(
+                    'pagseguro-checkout-sdk',
+                    'https://assets.pagseguro.com.br/checkout-sdk-js/rc/dist/browser/pagseguro.min.js',
+                    [],
+                    WC_PAGSEGURO_CONNECT_VERSION,
+                    true
+                );
+            }
         }
 
         $isCheckoutBlocks = Functions::isCheckoutBlocks();
-        if ( is_checkout() && !is_order_received_page() && !$isCheckoutBlocks ) {
+        if ($force || (is_checkout() && !is_order_received_page() && !$isCheckoutBlocks) ) {
             $alreadyEnqueued = wp_script_is('pagseguro-connect-checkout');
             if (!$alreadyEnqueued) {
                 wp_enqueue_script(


### PR DESCRIPTION
…plugin de checkout utilizado, alguns arquivos JavaScript não eram inseridos, ocasionando erros na criptografia do cartao, aplicação de máscaras, e consequentemente impedindo a finalização de pedidos com Cartão de Crédito em checkouts diferentes do checkout em bloco


@ligiasalzano você poderia testar esse PR com Fluid Checkout, WC Checkout e Cartflows checkout (além dos checkouts que já temos)? Se puder, também teste configurando a pagina de checkout pra legado e depois pra checkout em blocos, _just in case_