### PR TITLE
Correção/melhoria: em alguns cenários onde campos do checkout eram om…

### DIFF
--- a/public/js/checkout.js
+++ b/public/js/checkout.js
@@ -44,6 +44,7 @@ jQuery(document).ready(function($) {
         const parameters = {
             'amount.value': 'valor do pedido',
             'customer.name': 'nome do cliente',
+            'customer.phones': 'telefone do cliente',
             'customer.phones[0].number': 'número de telefone do cliente',
             'customer.phones[0].area': 'DDD do telefone do cliente',
             'billingAddress.complement': 'complemento/bairro do endereço de cobrança',

--- a/public/js/creditcard.js
+++ b/public/js/creditcard.js
@@ -336,13 +336,13 @@ jQuery(document).ready(function ($) {
                     currency: 'BRL'
                 },
                 billingAddress: {
-                    street: checkoutFormDataObj['billing_address_1'].replace(/\s+/g, ' '),
-                    number: checkoutFormDataObj['billing_number'].replace(/\s+/g, ' '),
-                    complement: checkoutFormDataObj['billing_neighborhood'].replace(/\s+/g, ' '),
-                    regionCode: checkoutFormDataObj['billing_state'].replace(/\s+/g, ' ').toUpperCase(),
+                    street: checkoutFormDataObj['billing_address_1'] ? checkoutFormDataObj['billing_address_1'].replace(/\s+/g, ' ') : 'Rua não informada',
+                    number: checkoutFormDataObj['billing_number'] ? checkoutFormDataObj['billing_number'].replace(/\s+/g, ' ') : 'n/d',
+                    complement: checkoutFormDataObj['billing_neighborhood'] ? checkoutFormDataObj['billing_neighborhood'].replace(/\s+/g, ' ') : 'n/d',
+                    regionCode: checkoutFormDataObj['billing_state'] ? checkoutFormDataObj['billing_state'].replace(/\s+/g, ' ').toUpperCase() : 'SP',
                     country: 'BRA',
-                    city: checkoutFormDataObj['billing_city'].replace(/\s+/g, ' '),
-                    postalCode: checkoutFormDataObj['billing_postcode'].replace(/\D+/g, '')
+                    city: checkoutFormDataObj['billing_city'] ? checkoutFormDataObj['billing_city'].replace(/\s+/g, ' ') : 'n/d',
+                    postalCode: checkoutFormDataObj['billing_postcode'] ? checkoutFormDataObj['billing_postcode'].replace(/\D+/g, '') : '00000000'
                 }
         };
 


### PR DESCRIPTION
…itidos, a validação 3DS tornava o botão de Finalizar Compra inoperante devido a erros. Agora não só exibiremos o que pode ter dado errado, como também preenchemos alguns campos com valores como 'Nao informado' e 'n/d' a fim de garantir compatibilidade com tais tentativas e melhorar experiência do usuário nesses cenários.

@ligiasalzano share your thoughts! :)