### PR TITLE
Correção: em lojas com checkout em blocos, o método de calcular parce…

### DIFF
--- a/src/Connect/Blocks/CreditCard.php
+++ b/src/Connect/Blocks/CreditCard.php
@@ -98,7 +98,7 @@ final class CreditCard extends AbstractPaymentMethodType
             'isCartRecurring' => $recHelper->isCartRecurring(),
             'recurringTerms' => wp_kses($recHelper->getRecurringTermsFromCart('creditcard'), 'strong'),
             'paymentUnavailable' => $this->gateway->paymentUnavailable(),
-            'defaultInstallments' => is_checkout() && !$recHelper->isCartRecurring() ? $this->gateway->getDefaultInstallments() : null,
+            'defaultInstallments' => is_checkout() && !is_order_received_page() && !$recHelper->isCartRecurring() ? $this->gateway->getDefaultInstallments() : null,
             'ajax_url' => admin_url('admin-ajax.php'),
             'rm_pagbank_nonce' => wp_create_nonce('rm_pagbank_nonce')
         );


### PR DESCRIPTION
…las era chamado indevidamente na tela de sucesso de compra logando erros.