### PR TITLE
Enviando email de novo pedido para endereço de email de administração

### DIFF
--- a/src/Connect/Standalone/Boleto.php
+++ b/src/Connect/Standalone/Boleto.php
@@ -128,11 +128,6 @@ class Boleto extends WC_Payment_Gateway
         $shouldNotify = $order->get_status('edit') !== 'pending';
         $order->add_order_note('PagBank: Pedido criado com sucesso!', $shouldNotify);
 
-        // sends the new order email
-        if ($shouldNotify) {
-            $newOrderEmail = WC()->mailer()->emails['WC_Email_New_Order'];
-            $newOrderEmail->trigger($order->get_id());
-        }
 
         $woocommerce->cart->empty_cart();
         return array(
@@ -228,6 +223,7 @@ class Boleto extends WC_Payment_Gateway
             return;
         }
 
+        $this->sendNewOrder($order);
         $this->sendOrderInvoiceEmail($order);
     }
 }

--- a/src/Connect/Standalone/Pix.php
+++ b/src/Connect/Standalone/Pix.php
@@ -154,11 +154,6 @@ class Pix extends WC_Payment_Gateway
         $shouldNotify = $order->get_status('edit') !== 'pending';
         $order->add_order_note('PagBank: Pedido criado com sucesso!', $shouldNotify);
 
-        // sends the new order email
-        if ($shouldNotify) {
-            $newOrderEmail = WC()->mailer()->emails['WC_Email_New_Order'];
-            $newOrderEmail->trigger($order->get_id());
-        }
 
         $woocommerce->cart->empty_cart();
         return array(
@@ -238,6 +233,7 @@ class Pix extends WC_Payment_Gateway
             return;
         }
 
+        $this->sendNewOrder($order);
         $this->sendOrderInvoiceEmail($order);
     }
 }

--- a/src/Connect/Standalone/Redirect.php
+++ b/src/Connect/Standalone/Redirect.php
@@ -128,11 +128,6 @@ class Redirect extends WC_Payment_Gateway
         $shouldNotify = $order->get_status('edit') !== 'pending';
         $order->add_order_note('PagBank: Pedido criado com sucesso!', $shouldNotify);
 
-        // sends the new order email
-        if ($shouldNotify) {
-            $newOrderEmail = WC()->mailer()->emails['WC_Email_New_Order'];
-            $newOrderEmail->trigger($order->get_id());
-        }
 
         $woocommerce->cart->empty_cart();
         return array(
@@ -213,6 +208,7 @@ class Redirect extends WC_Payment_Gateway
             return;
         }
 
+        $this->sendNewOrder($order);
         $this->sendOrderInvoiceEmail($order);
     }
 

--- a/src/Traits/OrderInvoiceEmail.php
+++ b/src/Traits/OrderInvoiceEmail.php
@@ -22,4 +22,21 @@ trait OrderInvoiceEmail
             $order->add_order_note('PagBank: Erro ao enviar email do pedido: ' . $e->getMessage());
         }
     }
+
+    public function sendNewOrder($order)
+    {
+        try {
+            $emailHasBeenSent = wc_string_to_bool($order->get_meta('pagbank_email_new_order_sent'));
+
+            if ($emailHasBeenSent) {
+                return;
+            }
+
+            $customerInvoiceEmail = WC()->mailer()->emails['WC_Email_New_Order'];
+            $customerInvoiceEmail->trigger($order->get_id());
+            $order->add_meta_data('pagbank_email_new_order_sent', 'yes', true);
+        } catch (\Exception $e) {
+            $order->add_order_note('PagBank: Erro ao enviar email de novo pedido: ' . $e->getMessage());
+        }
+    }
 }


### PR DESCRIPTION
Notei que havia uma verificação (if) para checar se o status do pedido era pending. Se o status fosse diferente, o e-mail de novo pedido (WC_Email_New_Order) era disparado para o administrador.

No caso de compras realizadas com cartão de crédito, o pedido nunca fica com status pending, por isso o e-mail era enviado corretamente.

Já com outros meios de pagamento, como Pix, Boleto e Redirect, o pedido é sempre criado com o status pending, o que fazia com que ele não entrasse nessa condição e, consequentemente, o e-mail não era disparado.

Para resolver isso, removi essa verificação de status (pending) para os métodos Pix, Boleto e Redirect, e adicionei uma função na trait OrderInvoiceEmail que garante que o e-mail será disparado apenas uma vez, caso a configuração de envio de e-mail esteja ativada.